### PR TITLE
Avoid spawn errors on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prompt": "^0.2.14",
     "pw": "0.0.4",
     "rimraf": "^2.2.8",
+    "spawn-cmd": "0.0.2",
     "step": "0.0.5",
     "strider-ecosystem-client": "1.2.1",
     "strider-extension-loader": "^0.4.4",

--- a/plugin_manager/git.js
+++ b/plugin_manager/git.js
@@ -1,4 +1,4 @@
-var spawn = require('child_process').spawn
+var spawn = require('spawn-cmd').spawn;
 
 module.exports = {
   clone: function(repo, tag, path, cb) {

--- a/plugin_manager/npm.js
+++ b/plugin_manager/npm.js
@@ -1,4 +1,4 @@
-var spawn = require('child_process').spawn
+var spawn = require('spawn-cmd').spawn;
 
 module.exports = function(cwd) {
   return {


### PR DESCRIPTION
child_process.spawn does not behave the same way on Windows as it does on unixy OSs. It more or less expects the executable to be available in cwd. This can cause process starts to fail.
Using spawn-cmd resolves this particular error case.

Relates to #14