### PR TITLE
Don't install devDependencies

### DIFF
--- a/plugin_manager/npm.js
+++ b/plugin_manager/npm.js
@@ -3,7 +3,7 @@ var spawn = require('spawn-cmd').spawn;
 module.exports = function(cwd) {
   return {
     install: function(cb) {
-      var proc = spawn('npm', [ 'install' ], {
+      var proc = spawn('npm', [ 'install', '--production' ], {
         stdio: 'inherit',
         cwd: cwd
       })


### PR DESCRIPTION
npm install will install devDependencies by default, this is not required and just consumes bandwidth and diskspace.

From [`npm install` docs](https://docs.npmjs.com/cli/install):

> By default, npm install will install all modules listed as dependencies. With the --production flag (or when the NODE_ENV environment variable is set to production), npm will not install modules listed in devDependencies.