### PR TITLE
Include title of local plugins

### DIFF
--- a/plugin_manager/local_plugins.js
+++ b/plugin_manager/local_plugins.js
@@ -36,7 +36,8 @@ module.exports = function(pluginsPath) {
             group: groupName,
             name: pluginName,
             path: plugin.dir,
-            version: getVersion(plugin.dir)
+            version: getVersion(plugin.dir),
+            title: plugin.title
           })
         }
       }


### PR DESCRIPTION
Currently, the title attribute of local plugins is not included in the plugin objects created in local_plugins.js, which means that the Admin interface does not have access to this attribute for local plugins (because local plugins are sourced from strider-cli, unlike remote plugins which are sourced from the config.yml). This PR adds `title` as a property for local plugins so that it can be utilized by other components such as the admin interface